### PR TITLE
feat: update usage message to use @fetch-post

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ impl EventHandler for Bot {
             if let Err(e) = msg
                 .reply(
                     &ctx.http,
-                    "使い方: @bot 123 または @bot 123-128 または @bot 123- または @bot 123,124-128,^126-127 または @bot ?324,?324-326,?^325",
+                    "使い方: @fetch-post 123 または @fetch-post 123-128 または @fetch-post 123- または @fetch-post 123,124-128,^322,?324-326,?^325",
                 )
                 .await
             {


### PR DESCRIPTION
## Summary
- Updated the usage message to use `@fetch-post` instead of `@bot`
- Changed the example to be more realistic and descriptive

## Changes
- Changed mention from `@bot` to `@fetch-post` throughout the usage message
- Updated the last example from `^126-127 または @bot ?324,?324-326,?^325` to `^322,?324-326,?^325`
- This provides a clearer and more realistic example of combining exclusion and relative references

## Test Plan
- [x] Code compiles successfully
- [x] cargo fmt and cargo clippy pass
- [x] Bot responds with updated usage message when mentioned without arguments

🤖 Generated with [Claude Code](https://claude.ai/code)