### PR TITLE
fix: improve usage message format with separate example

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ impl EventHandler for Bot {
             if let Err(e) = msg
                 .reply(
                     &ctx.http,
-                    "使い方: @fetch-post 123 または @fetch-post 123-128 または @fetch-post 123- または @fetch-post 123,124-128,^322,?324-326,?^325",
+                    "使い方: @fetch-post 123 または @fetch-post 123-128 または @fetch-post 123- または @fetch-post 123,124-128 または @fetch-post ^322,?324-326,?^325",
                 )
                 .await
             {


### PR DESCRIPTION
## Summary
- Improved the usage message format by separating the complex example

## Changes
- Split `123,124-128,^322,?324-326,?^325` into `123,124-128 または @fetch-post ^322,?324-326,?^325`
- This makes the usage message more readable and easier to understand
- Each example now has its own `@fetch-post` prefix for clarity

## Before
```
使い方: @fetch-post 123 または @fetch-post 123-128 または @fetch-post 123- または @fetch-post 123,124-128,^322,?324-326,?^325
```

## After
```
使い方: @fetch-post 123 または @fetch-post 123-128 または @fetch-post 123- または @fetch-post 123,124-128 または @fetch-post ^322,?324-326,?^325
```

## Test Plan
- [x] Code compiles successfully
- [x] cargo fmt and cargo clippy pass
- [x] Bot responds with improved usage message when mentioned without arguments

🤖 Generated with [Claude Code](https://claude.ai/code)