### PR TITLE
feat: implement proper logging with log crate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+DISCORD_TOKEN=your_discord_bot_token_here
+DATABASE_URL=postgresql://username:password@localhost:5432/database_name
+IMAGE_URL_PREFIX=https://example.com/images/
+
+# Logging configuration (optional)
+# Options: error, warn, info, debug, trace
+# Default: info
+RUST_LOG=info
+
+# For debug builds or detailed logging:
+# RUST_LOG=debug
+# RUST_LOG=bbs_fetch_post_discord_bot=debug,serenity=info

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +178,8 @@ dependencies = [
  "anyhow",
  "chrono",
  "dotenvy",
+ "env_logger",
+ "log",
  "regex",
  "serde",
  "serenity",
@@ -243,6 +295,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "command_attr"
@@ -439,6 +497,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -1004,10 +1085,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "js-sys"
@@ -1220,6 +1331,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1301,6 +1418,21 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2519,6 +2651,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uwl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ regex = "1.10"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
+log = "0.4"
+env_logger = "0.11"

--- a/README.md
+++ b/README.md
@@ -224,6 +224,28 @@ CREATE TABLE res (
 DISCORD_TOKEN=your_discord_bot_token
 DATABASE_URL=postgresql://username:password@host:port/database
 IMAGE_URL_PREFIX=https://example.com/images/
+
+# ログレベル設定（オプション）
+# 設定可能な値: error, warn, info, debug, trace
+# デフォルト: info
+RUST_LOG=info
+```
+
+### ログレベルの設定
+
+`RUST_LOG`環境変数でログの詳細度を制御できます：
+
+- `RUST_LOG=error`: エラーのみ表示
+- `RUST_LOG=warn`: 警告とエラーを表示
+- `RUST_LOG=info`: 情報、警告、エラーを表示（デフォルト）
+- `RUST_LOG=debug`: デバッグ情報を含むすべてのログを表示
+- `RUST_LOG=trace`: 最も詳細なログを表示
+
+特定のモジュールのログレベルを個別に設定することも可能です：
+
+```env
+# botのデバッグログを表示し、serenityは情報レベルのみ
+RUST_LOG=bbs_fetch_post_discord_bot=debug,serenity=info
 ```
 
 ## 依存関係

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub async fn get_res_by_numbers(pool: &PgPool, numbers: Vec<i32>) -> Result<Vec<
     }
 
     let query = "SELECT * FROM res WHERE no = ANY($1) ORDER BY no ASC";
-    debug!("get_res_by_numbers: querying for numbers: {:?}", numbers);
+    debug!("get_res_by_numbers: querying for numbers: {numbers:?}");
 
     let result = sqlx::query_as::<_, Res>(query)
         .bind(&numbers)
@@ -47,7 +47,7 @@ pub async fn get_res_by_numbers(pool: &PgPool, numbers: Vec<i32>) -> Result<Vec<
 
     match &result {
         Ok(posts) => debug!("get_res_by_numbers: found {} posts", posts.len()),
-        Err(e) => error!("get_res_by_numbers: error: {:?}", e),
+        Err(e) => error!("get_res_by_numbers: error: {e:?}"),
     }
 
     result
@@ -59,7 +59,7 @@ pub async fn get_max_post_number(pool: &PgPool) -> Result<i32> {
 
     let row: (Option<i32>,) = sqlx::query_as(query).fetch_one(pool).await?;
     let result = row.0.unwrap_or(0);
-    debug!("get_max_post_number: result = {}", result);
+    debug!("get_max_post_number: result = {result}");
 
     Ok(result)
 }
@@ -149,8 +149,7 @@ pub fn parse_range_specifications(input: &str) -> Vec<RangeSpec> {
 
 pub fn calculate_post_numbers(specs: Vec<RangeSpec>, max_post_number: i32) -> Vec<i32> {
     debug!(
-        "calculate_post_numbers called with specs: {:?}, max_post_number: {}",
-        specs, max_post_number
+        "calculate_post_numbers called with specs: {specs:?}, max_post_number: {max_post_number}"
     );
     let mut included = HashSet::new();
     let mut excluded = HashSet::new();
@@ -177,8 +176,7 @@ pub fn calculate_post_numbers(specs: Vec<RangeSpec>, max_post_number: i32) -> Ve
             candidate
         };
 
-        trace!("calculate_absolute: max={}, relative={}, digits={}, divisor={}, base={}, candidate={}, result={}", 
-                 max_post_number, relative_num, digit_count, divisor, base, candidate, result);
+        trace!("calculate_absolute: max={max_post_number}, relative={relative_num}, digits={digit_count}, divisor={divisor}, base={base}, candidate={candidate}, result={result}");
 
         result
     };
@@ -218,18 +216,17 @@ pub fn calculate_post_numbers(specs: Vec<RangeSpec>, max_post_number: i32) -> Ve
             // Relative references
             RangeSpec::RelativeInclude(start, end, digit_count) => {
                 debug!(
-                    "Processing RelativeInclude: start={}, end={:?}, digit_count={}",
-                    start, end, digit_count
+                    "Processing RelativeInclude: start={start}, end={end:?}, digit_count={digit_count}"
                 );
                 let abs_start = calculate_absolute(start, digit_count);
                 if let Some(end_num) = end {
                     let abs_end = calculate_absolute(end_num, digit_count);
-                    debug!("Including range {}..={}", abs_start, abs_end);
+                    debug!("Including range {abs_start}..={abs_end}");
                     for i in abs_start..=abs_end {
                         included.insert(i);
                     }
                 } else {
-                    debug!("Including single number {}", abs_start);
+                    debug!("Including single number {abs_start}");
                     included.insert(abs_start);
                 }
             }
@@ -241,18 +238,17 @@ pub fn calculate_post_numbers(specs: Vec<RangeSpec>, max_post_number: i32) -> Ve
             }
             RangeSpec::RelativeExclude(start, end, digit_count) => {
                 debug!(
-                    "Processing RelativeExclude: start={}, end={:?}, digit_count={}",
-                    start, end, digit_count
+                    "Processing RelativeExclude: start={start}, end={end:?}, digit_count={digit_count}"
                 );
                 let abs_start = calculate_absolute(start, digit_count);
                 if let Some(end_num) = end {
                     let abs_end = calculate_absolute(end_num, digit_count);
-                    debug!("Excluding range {}..={}", abs_start, abs_end);
+                    debug!("Excluding range {abs_start}..={abs_end}");
                     for i in abs_start..=abs_end {
                         excluded.insert(i);
                     }
                 } else {
-                    debug!("Excluding single number {}", abs_start);
+                    debug!("Excluding single number {abs_start}");
                     excluded.insert(abs_start);
                 }
             }
@@ -267,10 +263,7 @@ pub fn calculate_post_numbers(specs: Vec<RangeSpec>, max_post_number: i32) -> Ve
 
     let mut result: Vec<i32> = included.difference(&excluded).cloned().collect();
     result.sort();
-    debug!(
-        "Final result - included: {:?}, excluded: {:?}, result: {:?}",
-        included, excluded, result
-    );
+    debug!("Final result - included: {included:?}, excluded: {excluded:?}, result: {result:?}");
     result
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ impl EventHandler for Bot {
 
         // Parse range specifications
         let specs = parse_range_specifications(&cleaned_content);
-        debug!("Input: '{}', Parsed specs: {:?}", cleaned_content, specs);
+        debug!("Input: '{cleaned_content}', Parsed specs: {specs:?}");
 
         if specs.is_empty() {
             if let Err(e) = msg
@@ -52,7 +52,7 @@ impl EventHandler for Bot {
 
         // Check if any spec requires max post number
         let needs_max = specs.iter().any(|spec| {
-            debug!("Checking spec {:?} for needs_max", spec);
+            debug!("Checking spec {spec:?} for needs_max");
             matches!(
                 spec,
                 RangeSpec::IncludeFrom(_)
@@ -63,12 +63,12 @@ impl EventHandler for Bot {
                     | RangeSpec::RelativeExcludeFrom(_, _)
             )
         });
-        debug!("needs_max = {}", needs_max);
+        debug!("needs_max = {needs_max}");
 
         let max_post_number = if needs_max {
             match get_max_post_number(&self.pool).await {
                 Ok(max) => {
-                    debug!("Got max post number: {}", max);
+                    debug!("Got max post number: {max}");
                     max
                 }
                 Err(e) => {
@@ -87,7 +87,7 @@ impl EventHandler for Bot {
         };
 
         let post_numbers = calculate_post_numbers(specs, max_post_number);
-        debug!("Calculated post numbers: {:?}", post_numbers);
+        debug!("Calculated post numbers: {post_numbers:?}");
 
         if post_numbers.is_empty() {
             if let Err(e) = msg


### PR DESCRIPTION
## Summary
- Replaced debug eprintln\! statements with proper logging using the `log` crate
- Added support for configurable log levels via `RUST_LOG` environment variable
- Debug logs now only appear in debug builds or when explicitly enabled

## Changes

### Dependencies Added
- `log = "0.4"` - The standard Rust logging facade
- `env_logger = "0.11"` - Logger implementation that reads from RUST_LOG

### Code Changes
- Replaced all `eprintln\!("DEBUG: ...")` with appropriate log macros:
  - `error\!()` for errors
  - `debug\!()` for debug information
  - `info\!()` for general information
  - `trace\!()` for very detailed debug info
- Added `env_logger::init()` in main to initialize logging

### Documentation
- Created `.env.example` with logging configuration examples
- Updated README with logging configuration section
- Added examples of different log levels and module-specific logging

## Usage

Set the `RUST_LOG` environment variable to control log verbosity:

```bash
# Show only errors (production)
RUST_LOG=error cargo run

# Show debug logs for troubleshooting
RUST_LOG=debug cargo run

# Show debug logs only for this bot, info for other crates
RUST_LOG=bbs_fetch_post_discord_bot=debug,serenity=info cargo run

# Most verbose logging
RUST_LOG=trace cargo run
```

## Benefits
- Production logs are clean by default (info level)
- Debug information is available when needed without recompiling
- Follows Rust logging best practices
- Can debug specific modules without flooding logs

## Test Plan
- [x] Code compiles successfully
- [x] cargo fmt and cargo clippy pass (with minor warnings)
- [x] Bot runs with default log level (info)
- [x] Debug logs appear when RUST_LOG=debug
- [x] No debug output when RUST_LOG=error

🤖 Generated with [Claude Code](https://claude.ai/code)